### PR TITLE
Support all valid Git URI-ish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 }
 
 stutter {
-  supports '3.0', '3.1', '3.2', '3.2.1'
+  supports '3.0', '3.1', '3.2', '3.2.1', '3.3', '3.4-rc-3'
 }
 
 model {
@@ -56,5 +56,5 @@ pluginBundle {
 }
 
 wrapper {
-  gradleVersion = '3.2'
+  gradleVersion = '3.3'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Nov 05 15:55:20 CDT 2016
+#Thu Feb 16 18:55:04 CST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-bin.zip

--- a/src/main/groovy/org/ajoberstar/gradle/git/publish/GitPublishPlugin.groovy
+++ b/src/main/groovy/org/ajoberstar/gradle/git/publish/GitPublishPlugin.groovy
@@ -29,6 +29,7 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.Copy
 import org.gradle.api.file.FileTree
+import org.eclipse.jgit.transport.URIish
 
 class GitPublishPlugin implements Plugin<Project> {
   @PackageScope static final String RESET_TASK = 'gitPublishReset'
@@ -157,7 +158,8 @@ class GitPublishPlugin implements Plugin<Project> {
       Optional.of(Grgit.open(dir: extension.repoDir))
         .filter { repo ->
           String originUri = repo.remote.list().find { it.name == 'origin' }?.url
-          boolean valid = new URI(extension.repoUri) == new URI(originUri) && extension.branch == repo.branch.current.name
+          // need to use the URIish to normalize them and ensure we support all Git compatible URI-ishs (URL is too limiting)
+          boolean valid = new URIish(extension.repoUri) == new URIish(originUri) && extension.branch == repo.branch.current.name
           if (!valid) { repo.close() }
           return valid
         }


### PR DESCRIPTION
Remotes can use a variety of URI-like values. The checks to validate
that an existing repo is pointing to the correct repository need to
normalize the uris to ensure that minor differences in syntax are
ignored if they are effectively equal. Previously, URL was used for this
normalization, but that cut out the SSH and similar uri-ish types
supported by Git. Using the URIish class from JGit fixes this problem.

Fixes #18.