### PR TITLE
Don't use input/outputs for tasks

### DIFF
--- a/src/main/groovy/org/ajoberstar/gradle/git/publish/GitPublishPlugin.groovy
+++ b/src/main/groovy/org/ajoberstar/gradle/git/publish/GitPublishPlugin.groovy
@@ -71,6 +71,7 @@ class GitPublishPlugin implements Plugin<Project> {
     task.with {
       group = 'publishing'
       description = 'Prepares a git repo for new content to be generated.'
+
       // get the repo in place
       doFirst {
         Grgit repo = findExistingRepo(project, extension).orElseGet { freshRepo(extension) }
@@ -121,12 +122,16 @@ class GitPublishPlugin implements Plugin<Project> {
   }
 
   private Task createCopyTask(Project project, GitPublishExtension extension) {
-    Task task = project.tasks.create(COPY_TASK, Copy)
+    Task task = project.tasks.create(COPY_TASK)
     task.with {
       group = 'publishing'
       description = 'Copy contents to be published to git.'
-      with extension.contents
-      into { extension.repoDir }
+      doLast {
+        project.copy {
+          with extension.contents
+          into { extension.repoDir }
+        }
+      }
     }
     return task
   }


### PR DESCRIPTION
As of Gradle 4.2 [1], when execution of a task begins, any "stale" outputs
will be deleted. All files under build and any declared outputs are
considered managed by Gradle. If other files happen to be in there,
Gradle will delete them.

The reset task did not declare any outputs, but created the
build/gitPublish directory and cloned the repo in there. When the copy
task rolls around, which is a built in task with declared
inputs/outputs, it sees some that cloned repo as stale files in its
output directory, since the copy task didn't put them there. Since they
are also under build, Gradle considers itself the owner and thinks it's
safe to delete them.

Since the inputs/outputs of the tasks in this plugin both overlap and
sometimes aren't clear files in / files out situations, it is easier for
now to drop using them altogether.

This commit drops the use of the Copy task, in favor of a ad-hoc task
that uses project.copy. This was the only task that had any
inputs/outputs declared before, so this issue should no longer be able
to present.

This fixes #35.

[1] https://docs.gradle.org/4.2/release-notes.html#safer-handling-of-stale-output-files