### PR TITLE
Don't close grgit if it's not present

### DIFF
--- a/src/compatTest/groovy/org/ajoberstar/gradle/git/publish/BaseCompatTest.groovy
+++ b/src/compatTest/groovy/org/ajoberstar/gradle/git/publish/BaseCompatTest.groovy
@@ -7,6 +7,7 @@ import org.ajoberstar.grgit.Grgit
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 
@@ -239,14 +240,32 @@ gitPublish {
     working.branch.list()*.name == ['gh-pages']
   }
 
+  def 'when no git publish tasks are run, build completes successfully'() {
+    given:
+    buildFile << '''\
+plugins {
+  id 'org.ajoberstar.git-publish'
+}
 
-  private BuildResult build() {
+task hello {
+  doLast {
+    println 'Hello!'
+  }
+}
+'''
+    when:
+    build('hello')
+    then:
+    notThrown(UnexpectedBuildFailure)
+  }
+
+  private BuildResult build(String... args = ['gitPublishPush', '--stacktrace']) {
     return GradleRunner.create()
       .withGradleVersion(System.properties['compat.gradle.version'])
       .withPluginClasspath()
       .withProjectDir(projectDir)
       .forwardOutput()
-      .withArguments('gitPublishPush', '--stacktrace')
+      .withArguments(args)
       .build()
   }
 

--- a/src/main/java/org/ajoberstar/gradle/git/publish/GitPublishPlugin.java
+++ b/src/main/java/org/ajoberstar/gradle/git/publish/GitPublishPlugin.java
@@ -46,7 +46,9 @@ public class GitPublishPlugin implements Plugin<Project> {
     // always close the repo at the end of the build
     project.getGradle().buildFinished(result -> {
       project.getLogger().info("Closing Git publish repo: {}", extension.getRepoDir().get());
-      reset.getGrgit().get().close();
+      if (reset.getGrgit().isPresent()) {
+        reset.getGrgit().get().close();
+      }
     });
   }
 


### PR DESCRIPTION
The previous change to leverage the reset task to set the grgit property
meant that if reset doesn't run, the grgit property won't be set. Gradle
doesn't let you access an unset property, so you get a failure like
this:

    * What went wrong:
    No value has been specified for this provider.

So we need to just do a safety check before trying to close grgit.

This fixes #51, since a user confirmed the previous change resolved
the origin not found scenario.