### PR TITLE
Configure gradle build scan plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ defaults: &defaults
         at: "."
     - run:
         name: Compile and test
-        command: ./gradlew clean check --continue
+        command: ./gradlew clean check --continue --scan
     - save_cache:
         paths:
           - "~/.gradle/caches"

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,12 @@ plugins {
   id 'groovy'
   id 'java-library'
   id 'java-gradle-plugin'
+  id 'com.gradle.build-scan' version '1.16'
+}
+
+buildScan {
+  termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
+  termsOfServiceAgree = 'yes'
 }
 
 apply from: 'gradle/bintray.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 plugins {
+  id 'com.gradle.build-scan' version '1.16'
   id 'org.ajoberstar.defaults' version '0.12.0'
   id 'groovy'
   id 'java-library'
   id 'java-gradle-plugin'
-  id 'com.gradle.build-scan' version '1.16'
 }
 
 buildScan {


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.